### PR TITLE
fix: blacklist spirit bomb & fracture internal casts

### DIFF
--- a/TrufiGCD.lua
+++ b/TrufiGCD.lua
@@ -55,6 +55,9 @@ local InnerBL = { --закрытый черный список, по ID
 	222031, -- Chaos Strike 1 (DemonHunter unverified fix)
 	197125, -- Chaos Strike 2 (DemonHunter unverified fix)
 	199547, -- Chaos Strike 3 (DemonHunter unverified fix)
+	227255, -- Spirit Bomb periodical
+	225919, -- Fracture double hit
+	225921, -- Fracture part 2
 }
 local cross = "Interface\\TargetingFrame\\UI-RaidTargetingIcon_7"
 local skull = "Interface\\TargetingFrame\\UI-RaidTargetingIcon_8"

--- a/TrufiGCD.lua
+++ b/TrufiGCD.lua
@@ -58,6 +58,7 @@ local InnerBL = { --закрытый черный список, по ID
 	227255, -- Spirit Bomb periodical
 	225919, -- Fracture double hit
 	225921, -- Fracture part 2
+	228478, -- Soul Cleave part 2
 }
 local cross = "Interface\\TargetingFrame\\UI-RaidTargetingIcon_7"
 local skull = "Interface\\TargetingFrame\\UI-RaidTargetingIcon_8"


### PR DESCRIPTION
Fracture before, after 1 cast:
![image](https://user-images.githubusercontent.com/29307652/164773163-4b8a3307-752e-413e-8291-cb4fa0f794d9.png)

Fracture after:
![image](https://user-images.githubusercontent.com/29307652/164773283-46e5090b-bb94-412d-b31e-022738fac346.png)

Spirit Bomb before, after 1 cast:
![image](https://user-images.githubusercontent.com/29307652/164773232-aa48fd9e-9329-4f78-b7af-efbbbe0c720f.png)

Spirit Bomb after:
![image](https://user-images.githubusercontent.com/29307652/164773312-cc4603a2-c4cd-4d9a-b5bb-7bdf7412769f.png)
