### PR TITLE
Dragonflight Compatibility: dont inherit from `OptionsBoxTemplate`

### DIFF
--- a/TrufiGCD.lua
+++ b/TrufiGCD.lua
@@ -59,8 +59,10 @@ local InnerBL = { --закрытый черный список, по ID
 	225919, -- Fracture double hit
 	225921, -- Fracture part 2
 	228478, -- Soul Cleave part 2
-    346665, -- Master of the Glaive (DH Class Tree Talent)
-    370966, -- The Hunt Impact (DH Class Tree Talent)
+	346665, -- Master of the Glaive (DH Class Tree Talent)
+	370966, -- The Hunt Impact (DH Class Tree Talent)
+	394007, -- Ready to Build (DF Engineering Accessoire)
+	391775, -- What's Cookin', Good Lookin'? (DF Cooking Accessoire)
 }
 local cross = "Interface\\TargetingFrame\\UI-RaidTargetingIcon_7"
 local skull = "Interface\\TargetingFrame\\UI-RaidTargetingIcon_8"

--- a/TrufiGCD.lua
+++ b/TrufiGCD.lua
@@ -703,7 +703,7 @@ function TrGCDBLAddSpell(self)
       		if (spellId ~= nil) then
         		table.insert(TrGCDBL, spellId)
         		if (spellId .. "") ~= spellname then -- only note if a string was passed
-          		print("[TrufiGCD]: converted \"" .. spellname .. "\" to spell id " .. spellId .. ". If this is not the desired spell id, provide the exat spell id of the spell you wish to blacklist as multiple spells with this name may exist.")
+          		print("[TrufiGCD]: converted \"" .. spellname .. "\" to spell id " .. spellId .. ". If this is not the desired spell id, provide the exact spell id of the spell you wish to blacklist as multiple spells with this name may exist.")
         		end
 
         		TrGCDLoadBlackList()

--- a/TrufiGCD.lua
+++ b/TrufiGCD.lua
@@ -59,8 +59,8 @@ local InnerBL = { --закрытый черный список, по ID
 	225919, -- Fracture double hit
 	225921, -- Fracture part 2
 	228478, -- Soul Cleave part 2
-  346665, -- Master of the Glaive (DH Class Tree Talent)
-  370966, -- The Hunt Impact (DH Class Tree Talent)
+    346665, -- Master of the Glaive (DH Class Tree Talent)
+    370966, -- The Hunt Impact (DH Class Tree Talent)
 }
 local cross = "Interface\\TargetingFrame\\UI-RaidTargetingIcon_7"
 local skull = "Interface\\TargetingFrame\\UI-RaidTargetingIcon_8"
@@ -669,12 +669,25 @@ function TrGCDEnterEventHandler(self, event, ...) -- эвент, когда иг
 end
 function TrGCDLoadBlackList() -- загрузка черного списка
 	for i=1,60 do
-    local id = id
-		if (id ~= nil) then
-			local spellname = GetSpellInfo(id)
-			if (spellname == nil) then spellname = id end
-			TrGCDGUI.BL.Spell[i]:Enable()
-			TrGCDGUI.BL.Spell[i].Text:SetText("" .. spellname .. " (" .. id .. ")")
+    	local idOrName = TrGCDBL[i]
+		if (idOrName ~= nil) then
+			local name, _, _, _, _, _, spellId = GetSpellInfo(idOrName)
+
+			if spellId then
+				TrGCDGUI.BL.Spell[i]:Enable()
+				TrGCDGUI.BL.Spell[i].Text:SetText(spellId .. " - " .. name)
+
+				-- 10.0 change; only store IDs going forward
+				if tonumber(idOrName) ~= spellId then
+					table.insert(TrGCDBL, i, spellId)
+				end
+			else
+				-- 10.0 change; remove abilities from blacklist that are not resolvable to an id
+				table.remove(TrGCDBL, i)
+				TrGCDGUI.BL.Spell[i]:Disable()
+				TrGCDGUI.BL.Spell[i].Text:SetText(nil)
+				TrGCDGUI.BL.Spell[i].Texture:SetAlpha(0)
+			end
 		else
 			TrGCDGUI.BL.Spell[i]:Disable()
 			TrGCDGUI.BL.Spell[i].Text:SetText(nil)
@@ -686,18 +699,18 @@ function TrGCDBLAddSpell(self)
 	if (TrGCDGUI.BL.AddEdit:GetText() ~= nil) then
 		local spellname = TrGCDGUI.BL.AddEdit:GetText()
 		if (#TrGCDBL < 60) then
-      local spellId = select(7, GetSpellInfo(spellname))
-      if (spellId ~= nil) then
-        table.insert(TrGCDBL, spellId)
-        if (spellId .. "") ~= spellname then -- only note if a string was passed
-          print("[TrufiGCD]: converted \"" .. spellname .. "\" to spell id " .. spellId .. ". If this is not the desired spell id, provide the exat spell id of the spell you wish to blacklist as multiple spells with this name may exist.")
-        end
+      		local spellId = select(7, GetSpellInfo(spellname))
+      		if (spellId ~= nil) then
+        		table.insert(TrGCDBL, spellId)
+        		if (spellId .. "") ~= spellname then -- only note if a string was passed
+          		print("[TrufiGCD]: converted \"" .. spellname .. "\" to spell id " .. spellId .. ". If this is not the desired spell id, provide the exat spell id of the spell you wish to blacklist as multiple spells with this name may exist.")
+        		end
 
-        TrGCDLoadBlackList()
-        TrGCDGUI.BL.AddEdit:SetText("")
-        TrGCDGUI.BL.AddEdit:ClearFocus()
-      end
-    end
+        		TrGCDLoadBlackList()
+        		TrGCDGUI.BL.AddEdit:SetText("")
+        		TrGCDGUI.BL.AddEdit:ClearFocus()
+      		end
+    	end
 	end
 end
 function TrGCDBLSaveSetting()

--- a/TrufiGCD.lua
+++ b/TrufiGCD.lua
@@ -59,6 +59,8 @@ local InnerBL = { --закрытый черный список, по ID
 	225919, -- Fracture double hit
 	225921, -- Fracture part 2
 	228478, -- Soul Cleave part 2
+  346665, -- Master of the Glaive (DH Class Tree Talent)
+  370966, -- The Hunt Impact (DH Class Tree Talent)
 }
 local cross = "Interface\\TargetingFrame\\UI-RaidTargetingIcon_7"
 local skull = "Interface\\TargetingFrame\\UI-RaidTargetingIcon_8"
@@ -211,7 +213,7 @@ function TrufiGCDAddonLoaded(self, event, ...)
 
 		TrGCDCheckToEnableAddon()
 		-- Options Panel Frame
-		TrGCDGUI = CreateFrame ("Frame", nil, UIParent, "OptionsBoxTemplate")
+		TrGCDGUI = CreateFrame ("Frame", nil, UIParent)
 		TrGCDGUI:Hide()
 		TrGCDGUI.name = "TrufiGCD"
 		--кнопка show/hide
@@ -379,7 +381,7 @@ function TrufiGCDAddonLoaded(self, event, ...)
 		end
 		InterfaceOptions_AddCategory(TrGCDGUI)
 		--добавления вкладки Spell Black List
-		TrGCDGUI.BL = CreateFrame ("Frame", nil, UIParent, "OptionsBoxTemplate")
+		TrGCDGUI.BL = CreateFrame ("Frame", nil, UIParent)
 		TrGCDGUI.BL:Hide()
 		TrGCDGUI.BL.name = "Blacklist"
 		TrGCDGUI.BL.parent = "TrufiGCD"
@@ -458,10 +460,12 @@ function TrufiGCDAddonLoaded(self, event, ...)
 		TrGCDGUI.BL.AddButt:SetScript("OnClick", function (self) TrGCDBLAddSpell(self) end)
 		TrGCDGUI.BL.AddEdit:SetScript("OnEnterPressed", function (self) TrGCDBLAddSpell(self) end)
 		TrGCDGUI.BL.AddEdit:SetScript("OnEscapePressed", function (self) self:ClearFocus() end)
-		TrGCDGUI.BL.AddButt.Text2 = TrGCDGUI.BL.List:CreateFontString(nil, "BACKGROUND")
+    TrGCDGUI.BL.AddButt.Text2 = TrGCDGUI.BL.AddButt:CreateFontString(nil, "BACKGROUND")
 		TrGCDGUI.BL.AddButt.Text2:SetFont("Fonts\\FRIZQT__.TTF", 11)
-		--TrGCDGUI.BL.AddButt.Text2:SetText("Blacklist can be loaded from the saved settings,\nbut does not restore the default.")
-		TrGCDGUI.BL.AddButt.Text2:SetPoint("BOTTOMLEFT", TrGCDGUI.BL.AddButt, "BOTTOMLEFT", 0, -35)
+		TrGCDGUI.BL.AddButt.Text2:SetText("You can only blacklist known abilities by name!")
+		TrGCDGUI.BL.AddButt.Text2:SetPoint("BOTTOMLEFT", TrGCDGUI.BL.AddButt, "BOTTOMLEFT",5, -15)
+
+
 		--кнопка загрузки настроек сохраненных в кэше
 		TrGCDGUI.BL.ButtonLoad = AddButton(TrGCDGUI.BL,"TOPRIGHT",-145,-30,22,100,"Load",10,"Load saving blacklist")
 		TrGCDGUI.BL.ButtonLoad:SetScript("OnClick", TrGCDBLLoadSetting)
@@ -665,11 +669,12 @@ function TrGCDEnterEventHandler(self, event, ...) -- эвент, когда иг
 end
 function TrGCDLoadBlackList() -- загрузка черного списка
 	for i=1,60 do
-		if (TrGCDBL[i] ~= nil) then
-			local spellname = GetSpellInfo(TrGCDBL[i])
-			if (spellname == nil) then spellname = TrGCDBL[i] end
+    local id = id
+		if (id ~= nil) then
+			local spellname = GetSpellInfo(id)
+			if (spellname == nil) then spellname = id end
 			TrGCDGUI.BL.Spell[i]:Enable()
-			TrGCDGUI.BL.Spell[i].Text:SetText(spellname)
+			TrGCDGUI.BL.Spell[i].Text:SetText("" .. spellname .. " (" .. id .. ")")
 		else
 			TrGCDGUI.BL.Spell[i]:Disable()
 			TrGCDGUI.BL.Spell[i].Text:SetText(nil)
@@ -681,15 +686,18 @@ function TrGCDBLAddSpell(self)
 	if (TrGCDGUI.BL.AddEdit:GetText() ~= nil) then
 		local spellname = TrGCDGUI.BL.AddEdit:GetText()
 		if (#TrGCDBL < 60) then
-		--local spellicon = select(3, GetSpellInfo(TrGCDGUI.BL.AddEdit:GetText()))
-		--if (spellicon ~= nil) then
-			table.insert(TrGCDBL, spellname)
-			TrGCDLoadBlackList()
-			--TrGCDGUI.BL.AddEdit:SetText("")
-			TrGCDGUI.BL.AddEdit:ClearFocus()
-			--TrGCDGUI.BL.AddButt.Text2:SetText()
-		--else TrGCDGUI.BL.AddButt.Text2:SetText('Spell not find, please try again.') end
-		end
+      local spellId = select(7, GetSpellInfo(spellname))
+      if (spellId ~= nil) then
+        table.insert(TrGCDBL, spellId)
+        if (spellId .. "") ~= spellname then -- only note if a string was passed
+          print("[TrufiGCD]: converted \"" .. spellname .. "\" to spell id " .. spellId .. ". If this is not the desired spell id, provide the exat spell id of the spell you wish to blacklist as multiple spells with this name may exist.")
+        end
+
+        TrGCDLoadBlackList()
+        TrGCDGUI.BL.AddEdit:SetText("")
+        TrGCDGUI.BL.AddEdit:ClearFocus()
+      end
+    end
 	end
 end
 function TrGCDBLSaveSetting()

--- a/TrufiGCD.toc
+++ b/TrufiGCD.toc
@@ -1,4 +1,4 @@
-## Interface: 90001
+## Interface: 100000
 ## Title: TrufiGCD
 ## Notes: View queue of last spells
 ## SavedVariables: TrufiGCDGlSave


### PR DESCRIPTION
works on dragonflight beta:

<details>
  <summary>beta</summary>
  
  ![image](https://user-images.githubusercontent.com/29307652/196054952-aea4fb5a-9a21-47ad-a42c-df4a9d86257e.png)
  ![image](https://user-images.githubusercontent.com/29307652/196057192-de2afec5-40a0-4e88-866a-f469a5d4ab5c.png)
  ![image](https://user-images.githubusercontent.com/29307652/196054963-1e1884f6-848c-4198-ac53-68f9ffd0f01c.png)
</details>

<details>
  <summary>retail</summary>
  
  ![image](https://user-images.githubusercontent.com/29307652/196057244-42f5279c-84fc-461e-9885-497e8e1298d6.png)
  ![image](https://user-images.githubusercontent.com/29307652/196057231-1e9e874d-efad-4f71-8312-c93ed58b7c56.png)
  ![image](https://user-images.githubusercontent.com/29307652/196057248-89f2edec-a627-48b6-b64f-8a98f59b2edb.png)
</details>

in addition, ive tested this with my character a bit and added new default blacklist entries.

this also kind of closes #15 without changing the behaviour too much:
- add note to blacklisting via name
- convert spell name to id
- print hint if spell name may be ambiguous

due to this change however, abilities that were previously blacklisted by name will now be attempted to be resolved to an id. if possible, they will be stored as id instead. if not possible, they will be removed.

note that despite the TOC Interface Version change, it is save to release this and it will load just fine on retail!
