### PR TITLE
Midnight Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 .DS_Store
 .idea
+.claude/

--- a/Modules/Constants.lua
+++ b/Modules/Constants.lua
@@ -5,13 +5,33 @@ local _, ns = ...
 local constants = {}
 ns.constants = constants
 
+constants.IsMidnight = select(4, GetBuildInfo()) >= 120000
+
 ---@type UnitType[]
 constants.unitTypes = {
-    "player", "party1", "party2", "party3", "party4",
-    "arena1", "arena2", "arena3", "target", "focus"
+	"player",
 }
+
+if not constants.IsMidnight then
+	table.insert(constants.unitTypes, "party1")
+	table.insert(constants.unitTypes, "party2")
+	table.insert(constants.unitTypes, "party3")
+	table.insert(constants.unitTypes, "party4")
+	table.insert(constants.unitTypes, "arena1")
+	table.insert(constants.unitTypes, "arena2")
+	table.insert(constants.unitTypes, "arena3")
+	table.insert(constants.unitTypes, "target")
+	table.insert(constants.unitTypes, "focus")
+end
 
 ---@type LayoutType[]
 constants.layoutTypes = {
-    "player", "party", "arena", "target", "focus"
+	"player",
 }
+
+if not constants.IsMidnight then
+	table.insert(constants.layoutTypes, "party")
+	table.insert(constants.layoutTypes, "arena")
+	table.insert(constants.layoutTypes, "target")
+	table.insert(constants.layoutTypes, "focus")
+end

--- a/Modules/Constants.lua
+++ b/Modules/Constants.lua
@@ -5,33 +5,31 @@ local _, ns = ...
 local constants = {}
 ns.constants = constants
 
-constants.IsMidnight = select(4, GetBuildInfo()) >= 120000
-
 ---@type UnitType[]
 constants.unitTypes = {
-	"player",
+    "player",
 }
 
 if not constants.IsMidnight then
-	table.insert(constants.unitTypes, "party1")
-	table.insert(constants.unitTypes, "party2")
-	table.insert(constants.unitTypes, "party3")
-	table.insert(constants.unitTypes, "party4")
-	table.insert(constants.unitTypes, "arena1")
-	table.insert(constants.unitTypes, "arena2")
-	table.insert(constants.unitTypes, "arena3")
-	table.insert(constants.unitTypes, "target")
-	table.insert(constants.unitTypes, "focus")
+    table.insert(constants.unitTypes, "party1");
+    table.insert(constants.unitTypes, "party2");
+    table.insert(constants.unitTypes, "party3");
+    table.insert(constants.unitTypes, "party4");
+    table.insert(constants.unitTypes, "arena1");
+    table.insert(constants.unitTypes, "arena2");
+    table.insert(constants.unitTypes, "arena3");
+    table.insert(constants.unitTypes, "target");
+    table.insert(constants.unitTypes, "focus");
 end
 
 ---@type LayoutType[]
 constants.layoutTypes = {
-	"player",
+    "player",
 }
 
 if not constants.IsMidnight then
-	table.insert(constants.layoutTypes, "party")
-	table.insert(constants.layoutTypes, "arena")
-	table.insert(constants.layoutTypes, "target")
-	table.insert(constants.layoutTypes, "focus")
+    table.insert(constants.layoutTypes, "party");
+    table.insert(constants.layoutTypes, "arena");
+    table.insert(constants.layoutTypes, "target");
+    table.insert(constants.layoutTypes, "focus");
 end

--- a/Modules/Constants.lua
+++ b/Modules/Constants.lua
@@ -10,6 +10,8 @@ constants.unitTypes = {
     "player",
 }
 
+constants.IsMidnight = (select(4, GetBuildInfo()) >= 120000);
+
 if not constants.IsMidnight then
     table.insert(constants.unitTypes, "party1");
     table.insert(constants.unitTypes, "party2");

--- a/Modules/Core/Units.lua
+++ b/Modules/Core/Units.lua
@@ -231,17 +231,20 @@ end
 
 ---@type {[UnitType]: LayoutType}
 local unitTypeToLayoutType = {
-    player = "player",
-    party1 = "party",
-    party2 = "party",
-    party3 = "party",
-    party4 = "party",
-    arena1 = "arena",
-    arena2 = "arena",
-    arena3 = "arena",
-    target = "target",
-    focus = "focus",
+	player = "player",
 }
+
+if not ns.constants.IsMidnight then
+	unitTypeToLayoutType.party1 = "party"
+	unitTypeToLayoutType.party2 = "party"
+	unitTypeToLayoutType.party3 = "party"
+	unitTypeToLayoutType.party4 = "party"
+	unitTypeToLayoutType.arena1 = "arena"
+	unitTypeToLayoutType.arena2 = "arena"
+	unitTypeToLayoutType.arena3 = "arena"
+	unitTypeToLayoutType.target = "target"
+	unitTypeToLayoutType.focus = "focus"
+end
 
 ns.units = {}
 for unitType, layoutType in pairs(unitTypeToLayoutType) do

--- a/Modules/Core/Units.lua
+++ b/Modules/Core/Units.lua
@@ -231,19 +231,19 @@ end
 
 ---@type {[UnitType]: LayoutType}
 local unitTypeToLayoutType = {
-	player = "player",
+    player = "player",
 }
 
 if not ns.constants.IsMidnight then
-	unitTypeToLayoutType.party1 = "party"
-	unitTypeToLayoutType.party2 = "party"
-	unitTypeToLayoutType.party3 = "party"
-	unitTypeToLayoutType.party4 = "party"
-	unitTypeToLayoutType.arena1 = "arena"
-	unitTypeToLayoutType.arena2 = "arena"
-	unitTypeToLayoutType.arena3 = "arena"
-	unitTypeToLayoutType.target = "target"
-	unitTypeToLayoutType.focus = "focus"
+    unitTypeToLayoutType.party1 = "party"
+    unitTypeToLayoutType.party2 = "party"
+    unitTypeToLayoutType.party3 = "party"
+    unitTypeToLayoutType.party4 = "party"
+    unitTypeToLayoutType.arena1 = "arena"
+    unitTypeToLayoutType.arena2 = "arena"
+    unitTypeToLayoutType.arena3 = "arena"
+    unitTypeToLayoutType.target = "target"
+    unitTypeToLayoutType.focus = "focus"
 end
 
 ns.units = {}

--- a/Modules/Frames/SettingsFrame.lua
+++ b/Modules/Frames/SettingsFrame.lua
@@ -10,6 +10,7 @@ frame:Hide()
 frame.name = "TrufiGCD"
 local category = ns.utils.interfaceOptions_AddCategory(frame)
 settingsFrame.frame = frame
+settingsFrame.category = category
 
 SLASH_TRUFI1, SLASH_TRUFI2 = '/tgcd', '/trufigcd'
 function SlashCmdList.TRUFI()
@@ -64,7 +65,7 @@ frameShowAnchorsButtonText:SetText('TrufiGCD')
 frameShowAnchorsButtonText:SetPoint("TOP", 0, -8)
 
 frameShowAnchorsReturnButton:SetScript("OnClick", function()
-    Settings.OpenToCategory(frame.name)
+    Settings.OpenToCategory(category:GetID())
 end)
 
 local anchorDisplayed = false

--- a/Modules/Frames/SettingsFrame.lua
+++ b/Modules/Frames/SettingsFrame.lua
@@ -13,7 +13,7 @@ settingsFrame.frame = frame
 
 SLASH_TRUFI1, SLASH_TRUFI2 = '/tgcd', '/trufigcd'
 function SlashCmdList.TRUFI()
-	Settings.OpenToCategory(category:GetID())
+    Settings.OpenToCategory(category:GetID())
 end
 
 ---show/hide anchors button, text and frame

--- a/Modules/Frames/SettingsFrame.lua
+++ b/Modules/Frames/SettingsFrame.lua
@@ -8,12 +8,12 @@ ns.settingsFrame = settingsFrame
 local frame = CreateFrame("Frame", nil, UIParent)
 frame:Hide()
 frame.name = "TrufiGCD"
-ns.utils.interfaceOptions_AddCategory(frame)
+local category = ns.utils.interfaceOptions_AddCategory(frame)
 settingsFrame.frame = frame
 
 SLASH_TRUFI1, SLASH_TRUFI2 = '/tgcd', '/trufigcd'
 function SlashCmdList.TRUFI()
-    Settings.OpenToCategory(frame.name)
+	Settings.OpenToCategory(category:GetID())
 end
 
 ---show/hide anchors button, text and frame

--- a/Modules/Settings/UnitSettings.lua
+++ b/Modules/Settings/UnitSettings.lua
@@ -3,19 +3,22 @@ local _, ns = ...
 
 ---@type {[UnitType]: string}
 local unitLabels = {
-    player = "Player",
-    party1 = "Party 1",
-    party2 = "Party 2",
-    party3 = "Party 3",
-    party4 = "Party 4",
-    arena1 = "Arena 1",
-    arena2 = "Arena 2",
-    arena3 = "Arena 3",
-    arena4 = "Arena 4",
-    arena5 = "Arena 5",
-    target = "Target",
-    focus = "Focus",
+	player = "Player",
 }
+
+if not ns.constants.IsMidnight then
+	unitLabels.party1 = "Party 1"
+	unitLabels.party2 = "Party 2"
+	unitLabels.party3 = "Party 3"
+	unitLabels.party4 = "Party 4"
+	unitLabels.arena1 = "Arena 1"
+	unitLabels.arena2 = "Arena 2"
+	unitLabels.arena3 = "Arena 3"
+	unitLabels.arena4 = "Arena 4"
+	unitLabels.arena5 = "Arena 5"
+	unitLabels.target = "Target"
+	unitLabels.focus = "Focus"
+end
 
 ---@class UnitSettings
 ---@field x number
@@ -28,33 +31,33 @@ ns.UnitSettings = UnitSettings
 
 ---@param unitType UnitType
 function UnitSettings:New(unitType)
-    ---@class UnitSettings
-    local obj = setmetatable({}, UnitSettings)
-    obj.text = unitLabels[unitType]
-    obj.x = 0
-    obj.y = 0
-    obj.point = "CENTER"
-    return obj
+	---@class UnitSettings
+	local obj = setmetatable({}, UnitSettings)
+	obj.text = unitLabels[unitType]
+	obj.x = 0
+	obj.y = 0
+	obj.point = "CENTER"
+	return obj
 end
 
 function UnitSettings:GetSavedVariables()
-    ---@type UnitVariablesV2
-    local savedVariables = {}
-    savedVariables.x = self.x
-    savedVariables.y = self.y
-    savedVariables.point = self.point
-    return savedVariables
+	---@type UnitVariablesV2
+	local savedVariables = {}
+	savedVariables.x = self.x
+	savedVariables.y = self.y
+	savedVariables.point = self.point
+	return savedVariables
 end
 
 ---@param savedVariables UnitVariablesV1 | UnitVariablesV2
 function UnitSettings:SetFromSavedVariables(savedVariables)
-    if type(savedVariables.x) == "number" then
-        self.x = savedVariables.x
-    end
-    if type(savedVariables.y) == "number" then
-        self.y = savedVariables.y
-    end
-    if type(savedVariables.point) == "string" then
-        self.point = savedVariables.point
-    end
+	if type(savedVariables.x) == "number" then
+		self.x = savedVariables.x
+	end
+	if type(savedVariables.y) == "number" then
+		self.y = savedVariables.y
+	end
+	if type(savedVariables.point) == "string" then
+		self.point = savedVariables.point
+	end
 end

--- a/Modules/Settings/UnitSettings.lua
+++ b/Modules/Settings/UnitSettings.lua
@@ -3,21 +3,21 @@ local _, ns = ...
 
 ---@type {[UnitType]: string}
 local unitLabels = {
-	player = "Player",
+    player = "Player",
 }
 
 if not ns.constants.IsMidnight then
-	unitLabels.party1 = "Party 1"
-	unitLabels.party2 = "Party 2"
-	unitLabels.party3 = "Party 3"
-	unitLabels.party4 = "Party 4"
-	unitLabels.arena1 = "Arena 1"
-	unitLabels.arena2 = "Arena 2"
-	unitLabels.arena3 = "Arena 3"
-	unitLabels.arena4 = "Arena 4"
-	unitLabels.arena5 = "Arena 5"
-	unitLabels.target = "Target"
-	unitLabels.focus = "Focus"
+    unitLabels.party1 = "Party 1";
+    unitLabels.party2 = "Party 2";
+    unitLabels.party3 = "Party 3";
+    unitLabels.party4 = "Party 4";
+    unitLabels.arena1 = "Arena 1";
+    unitLabels.arena2 = "Arena 2";
+    unitLabels.arena3 = "Arena 3";
+    unitLabels.arena4 = "Arena 4";
+    unitLabels.arena5 = "Arena 5";
+    unitLabels.target = "Target";
+    unitLabels.focus = "Focus";
 end
 
 ---@class UnitSettings
@@ -31,33 +31,33 @@ ns.UnitSettings = UnitSettings
 
 ---@param unitType UnitType
 function UnitSettings:New(unitType)
-	---@class UnitSettings
-	local obj = setmetatable({}, UnitSettings)
-	obj.text = unitLabels[unitType]
-	obj.x = 0
-	obj.y = 0
-	obj.point = "CENTER"
-	return obj
+    ---@class UnitSettings
+    local obj = setmetatable({}, UnitSettings)
+    obj.text = unitLabels[unitType]
+    obj.x = 0
+    obj.y = 0
+    obj.point = "CENTER"
+    return obj
 end
 
 function UnitSettings:GetSavedVariables()
-	---@type UnitVariablesV2
-	local savedVariables = {}
-	savedVariables.x = self.x
-	savedVariables.y = self.y
-	savedVariables.point = self.point
-	return savedVariables
+    ---@type UnitVariablesV2
+    local savedVariables = {}
+    savedVariables.x = self.x
+    savedVariables.y = self.y
+    savedVariables.point = self.point
+    return savedVariables
 end
 
 ---@param savedVariables UnitVariablesV1 | UnitVariablesV2
 function UnitSettings:SetFromSavedVariables(savedVariables)
-	if type(savedVariables.x) == "number" then
-		self.x = savedVariables.x
-	end
-	if type(savedVariables.y) == "number" then
-		self.y = savedVariables.y
-	end
-	if type(savedVariables.point) == "string" then
-		self.point = savedVariables.point
-	end
+    if type(savedVariables.x) == "number" then
+        self.x = savedVariables.x
+    end
+    if type(savedVariables.y) == "number" then
+        self.y = savedVariables.y
+    end
+    if type(savedVariables.point) == "string" then
+        self.point = savedVariables.point
+    end
 end

--- a/Modules/Utils.lua
+++ b/Modules/Utils.lua
@@ -6,89 +6,85 @@ local utils = {}
 ns.utils = utils
 
 utils.uuid = function()
-	local template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
-	return string.gsub(template, "[xy]", function(c)
-		local v = (c == "x") and math.random(0, 0xf) or math.random(8, 0xb)
-		return string.format("%x", v)
-	end)
+    local template ='xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
+    return string.gsub(template, '[xy]', function(c)
+        local v = (c == 'x') and math.random(0, 0xf) or math.random(8, 0xb)
+        return string.format('%x', v)
+    end)
 end
 
 ---@param collection table
 ---@return number
 utils.size = function(collection)
-	local size = 0
+    local size = 0
 
-	for _, _ in pairs(collection) do
-		size = size + 1
-	end
+    for _, _ in pairs(collection) do
+        size = size + 1
+    end
 
-	return size
+    return size
 end
 
 ---@return string
 utils.defaultProfileName = function()
-	return UnitName("player") .. " - " .. GetRealmName()
+    return UnitName("player") .. " - " .. GetRealmName()
 end
 
 ---@param spellId number | string
 ---@return string | nil, nil, number | nil, number | nil, number | nil, number | nil, number | nil, number | nil
 utils.getSpellInfo = function(spellId)
-	if GetSpellInfo then
-		return GetSpellInfo(spellId)
-	end
+    if GetSpellInfo then
+        return GetSpellInfo(spellId)
+    end
 
-	local spellInfo = C_Spell.GetSpellInfo(spellId)
-	if spellInfo then
-		return spellInfo.name,
-			nil,
-			spellInfo.iconID,
-			spellInfo.castTime,
-			spellInfo.minRange,
-			spellInfo.maxRange,
-			spellInfo.spellID,
-			spellInfo.originalIconID
-	end
+    local spellInfo = C_Spell.GetSpellInfo(spellId)
+    if spellInfo then
+        return spellInfo.name, nil, spellInfo.iconID, spellInfo.castTime, spellInfo.minRange, spellInfo.maxRange, spellInfo.spellID, spellInfo.originalIconID
+    end
 end
 
 ---@param spellId string | number
 ---@return string
 utils.getSpellLink = function(spellId)
-	if GetSpellLink then
-		return GetSpellLink(spellId)
-	else
-		return C_Spell.GetSpellLink(spellId)
-	end
+    if GetSpellLink then
+        return GetSpellLink(spellId)
+    else
+        return C_Spell.GetSpellLink(spellId)
+    end
+
 end
 
 local parentCategoryByName = {}
 
 utils.interfaceOptions_AddCategory = function(frame)
-	-- cancel is no longer a default option. May add menu extension for this.
-	frame.OnCommit = frame.okay
-	frame.OnDefault = frame.default
-	frame.OnRefresh = frame.refresh
+    -- cancel is no longer a default option. May add menu extension for this.
+    frame.OnCommit = frame.okay;
+    frame.OnDefault = frame.default;
+    frame.OnRefresh = frame.refresh;
 
-	if frame.parent then
-		local category = parentCategoryByName[frame.parent]
-		if category == nil then
-			error("Parent category not found: " .. frame.parent)
-		end
-		local subcategory = Settings.RegisterCanvasLayoutSubcategory(category, frame, frame.name, frame.name)
+    if frame.parent then
+        local category = parentCategoryByName[frame.parent];
 
-		if not ns.constants.IsMidnight then
-			subcategory.ID = frame.name
-		end
+        if category == nil then
+            error("Parent category not found: " .. frame.parent);
+        end
+        
+        local subcategory = Settings.RegisterCanvasLayoutSubcategory(category, frame, frame.name, frame.name);
+        
+        if not ns.constants.IsMidnight then
+            category.ID = frame.name;
+        end
 
-		return subcategory, category
-	else
-		local category = Settings.RegisterCanvasLayoutCategory(frame, frame.name, frame.name)
-		parentCategoryByName[frame.name] = category
+        return subcategory, category;
+    else
+        local category = Settings.RegisterCanvasLayoutCategory(frame, frame.name, frame.name);
+        parentCategoryByName[frame.name] = category;
 
-		if not ns.constants.IsMidnight then
-			category.ID = frame.name
-		end
+        if not ns.constants.IsMidnight then
+            category.ID = frame.name;
+        end
 
-		Settings.RegisterAddOnCategory(category)
-		return category
-	end
+        Settings.RegisterAddOnCategory(category);
+        return category;
+    end
 end

--- a/Modules/Utils.lua
+++ b/Modules/Utils.lua
@@ -6,69 +6,89 @@ local utils = {}
 ns.utils = utils
 
 utils.uuid = function()
-    local template ='xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
-    return string.gsub(template, '[xy]', function(c)
-        local v = (c == 'x') and math.random(0, 0xf) or math.random(8, 0xb)
-        return string.format('%x', v)
-    end)
+	local template = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
+	return string.gsub(template, "[xy]", function(c)
+		local v = (c == "x") and math.random(0, 0xf) or math.random(8, 0xb)
+		return string.format("%x", v)
+	end)
 end
 
 ---@param collection table
 ---@return number
 utils.size = function(collection)
-    local size = 0
+	local size = 0
 
-    for _, _ in pairs(collection) do
-        size = size + 1
-    end
+	for _, _ in pairs(collection) do
+		size = size + 1
+	end
 
-    return size
+	return size
 end
 
 ---@return string
 utils.defaultProfileName = function()
-    return UnitName("player") .. " - " .. GetRealmName()
+	return UnitName("player") .. " - " .. GetRealmName()
 end
 
 ---@param spellId number | string
 ---@return string | nil, nil, number | nil, number | nil, number | nil, number | nil, number | nil, number | nil
 utils.getSpellInfo = function(spellId)
-    if GetSpellInfo then
-        return GetSpellInfo(spellId)
-    end
+	if GetSpellInfo then
+		return GetSpellInfo(spellId)
+	end
 
-    local spellInfo = C_Spell.GetSpellInfo(spellId)
-    if spellInfo then
-        return spellInfo.name, nil, spellInfo.iconID, spellInfo.castTime, spellInfo.minRange, spellInfo.maxRange, spellInfo.spellID, spellInfo.originalIconID
-    end
+	local spellInfo = C_Spell.GetSpellInfo(spellId)
+	if spellInfo then
+		return spellInfo.name,
+			nil,
+			spellInfo.iconID,
+			spellInfo.castTime,
+			spellInfo.minRange,
+			spellInfo.maxRange,
+			spellInfo.spellID,
+			spellInfo.originalIconID
+	end
 end
 
 ---@param spellId string | number
 ---@return string
 utils.getSpellLink = function(spellId)
-    if GetSpellLink then
-        return GetSpellLink(spellId)
-    else
-        return C_Spell.GetSpellLink(spellId)
-    end
-
+	if GetSpellLink then
+		return GetSpellLink(spellId)
+	else
+		return C_Spell.GetSpellLink(spellId)
+	end
 end
 
-utils.interfaceOptions_AddCategory = function(frame)
-    -- cancel is no longer a default option. May add menu extension for this.
-    frame.OnCommit = frame.okay;
-    frame.OnDefault = frame.default;
-    frame.OnRefresh = frame.refresh;
+local parentCategoryByName = {}
 
-    if frame.parent then
-        local category = Settings.GetCategory(frame.parent);
-        local subcategory = Settings.RegisterCanvasLayoutSubcategory(category, frame, frame.name, frame.name);
-        subcategory.ID = frame.name;
-        return subcategory, category;
-    else
-        local category = Settings.RegisterCanvasLayoutCategory(frame, frame.name, frame.name);
-        category.ID = frame.name;
-        Settings.RegisterAddOnCategory(category);
-        return category;
-    end
+utils.interfaceOptions_AddCategory = function(frame)
+	-- cancel is no longer a default option. May add menu extension for this.
+	frame.OnCommit = frame.okay
+	frame.OnDefault = frame.default
+	frame.OnRefresh = frame.refresh
+
+	if frame.parent then
+		local category = parentCategoryByName[frame.parent]
+		if category == nil then
+			error("Parent category not found: " .. frame.parent)
+		end
+		local subcategory = Settings.RegisterCanvasLayoutSubcategory(category, frame, frame.name, frame.name)
+
+		if not ns.constants.IsMidnight then
+			subcategory.ID = frame.name
+		end
+
+		return subcategory, category
+	else
+		local category = Settings.RegisterCanvasLayoutCategory(frame, frame.name, frame.name)
+		parentCategoryByName[frame.name] = category
+
+		if not ns.constants.IsMidnight then
+			category.ID = frame.name
+		end
+
+		Settings.RegisterAddOnCategory(category)
+		return category
+	end
 end

--- a/Modules/Utils.lua
+++ b/Modules/Utils.lua
@@ -72,7 +72,7 @@ utils.interfaceOptions_AddCategory = function(frame)
         local subcategory = Settings.RegisterCanvasLayoutSubcategory(category, frame, frame.name, frame.name);
 
         if not ns.constants.IsMidnight then
-            category.ID = frame.name;
+            subcategory.ID = frame.name;
         end
 
         return subcategory, category;

--- a/Modules/Utils.lua
+++ b/Modules/Utils.lua
@@ -68,9 +68,9 @@ utils.interfaceOptions_AddCategory = function(frame)
         if category == nil then
             error("Parent category not found: " .. frame.parent);
         end
-        
+
         local subcategory = Settings.RegisterCanvasLayoutSubcategory(category, frame, frame.name, frame.name);
-        
+
         if not ns.constants.IsMidnight then
             category.ID = frame.name;
         end

--- a/TrufiGCD.lua
+++ b/TrufiGCD.lua
@@ -109,7 +109,7 @@ local function OnLoad()
             registerForAnyClick = true,
             func = function(_, btn)
                 if btn.buttonName == "LeftButton" then
-                    Settings.OpenToCategory(ns.settingsFrame.frame.name)
+                    Settings.OpenToCategory(ns.settingsFrame.category:GetID())
                 else
                     ns.settingsFrame.toggleAnchors()
                 end
@@ -136,7 +136,7 @@ else
     local loadFrame = CreateFrame("Frame", nil, UIParent)
     loadFrame:RegisterEvent("ADDON_LOADED")
     loadFrame:SetScript("OnEvent", function(self, event, name)
-        if name ~= "TrufiGCD" or event ~= "ADDON_LOADED" then
+        if name ~= addonName or event ~= "ADDON_LOADED" then
             return
         end
 

--- a/TrufiGCD.lua
+++ b/TrufiGCD.lua
@@ -11,139 +11,137 @@ local addonName, ns = ...
 ---@param unitB UnitType
 ---@return boolean
 local function areUnitsEqual(unitA, unitB)
-	local nameA = UnitName(unitA)
-	return nameA and nameA == UnitName(unitB) and UnitHealth(unitA) == UnitHealth(unitB)
+    local nameA = UnitName(unitA)
+    return nameA and nameA == UnitName(unitB) and UnitHealth(unitA) == UnitHealth(unitB)
 end
 
 ---@param unitType UnitType
 local function checkIfUnitAlreadyInUse(unitType)
-	for _, existedUnitType in ipairs(ns.constants.unitTypes) do
-		if areUnitsEqual(unitType, existedUnitType) then
-			ns.units[unitType]:Copy(ns.units[existedUnitType])
-			return
-		end
-	end
+    for _, existedUnitType in ipairs(ns.constants.unitTypes) do
+        if areUnitsEqual(unitType, existedUnitType) then
+            ns.units[unitType]:Copy(ns.units[existedUnitType])
+            return
+        end
+    end
 end
 
-do
-	local function OnLoad()
-		ns.settings:Load()
-		ns.settingsFrame.syncWithSettings()
-		ns.blocklistFrame.syncWithSettings()
-		ns.profileFrame.syncWithSettings()
+local function OnLoad()
+    ns.settings:Load()
+    ns.settingsFrame.syncWithSettings()
+    ns.blocklistFrame.syncWithSettings()
+    ns.profileFrame.syncWithSettings()
 
-		ns.locationCheck.settingsChanged()
+    ns.locationCheck.settingsChanged()
 
-		if not ns.constants.IsMidnight then
-			local targetFocusChangeFrame = CreateFrame("Frame", nil, UIParent)
-			targetFocusChangeFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
-			targetFocusChangeFrame:RegisterEvent("PLAYER_FOCUS_CHANGED")
-			targetFocusChangeFrame:SetScript("OnEvent", function(_, changeEvent)
-				if changeEvent == "PLAYER_TARGET_CHANGED" then
-					ns.units.target:Clear()
-					if ns.settings.activeProfile.layoutSettings.target.enable then
-						checkIfUnitAlreadyInUse("target")
-					end
-				elseif changeEvent == "PLAYER_FOCUS_CHANGED" then
-					ns.units.focus:Clear()
-					if ns.settings.activeProfile.layoutSettings.focus.enable then
-						checkIfUnitAlreadyInUse("focus")
-					end
-				end
-			end)
-		end
+    if not ns.constants.IsMidnight then
+        local targetFocusChangeFrame = CreateFrame("Frame", nil, UIParent)
+        targetFocusChangeFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
+        targetFocusChangeFrame:RegisterEvent("PLAYER_FOCUS_CHANGED")
+        targetFocusChangeFrame:SetScript("OnEvent", function(_, changeEvent)
+            if changeEvent == "PLAYER_TARGET_CHANGED" then
+                ns.units.target:Clear()
+                if ns.settings.activeProfile.layoutSettings.target.enable then
+                    checkIfUnitAlreadyInUse("target")
+                end
+            elseif changeEvent == "PLAYER_FOCUS_CHANGED" then
+                ns.units.focus:Clear()
+                if ns.settings.activeProfile.layoutSettings.focus.enable then
+                    checkIfUnitAlreadyInUse("focus")
+                end
+            end
+        end)
+    end
 
-		--Delay the initialisation to prevent odd abilities spam at the first world enter
-		C_Timer.After(0.5, function()
-			local spellEventFrame = CreateFrame("Frame", nil, UIParent)
-			if ns.constants.IsMidnight then
-				spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_START", "player")
-				spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_START", "player")
-				spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
-				spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_STOP", "player")
-				spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_STOP", "player")
-			else
-				spellEventFrame:RegisterEvent("UNIT_SPELLCAST_START")
-				spellEventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
-				spellEventFrame:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
-				spellEventFrame:RegisterEvent("UNIT_SPELLCAST_STOP")
-				spellEventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP")
-			end
+    --Delay the initialisation to prevent odd abilities spam at the first world enter
+    C_Timer.After(0.5, function()
+        local spellEventFrame = CreateFrame("Frame", nil, UIParent)
+        if ns.constants.IsMidnight then
+            spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_START", "player")
+            spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_START", "player")
+            spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
+            spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_STOP", "player")
+            spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_STOP", "player")
+        else
+            spellEventFrame:RegisterEvent("UNIT_SPELLCAST_START")
+            spellEventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
+            spellEventFrame:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
+            spellEventFrame:RegisterEvent("UNIT_SPELLCAST_STOP")
+            spellEventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP")
+        end
 
-			if IS_RETAIL then
-				if ns.constants.IsMidnight then
-					spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_EMPOWER_START", "player")
-					spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_EMPOWER_STOP", "player")
-				else
-					spellEventFrame:RegisterEvent("UNIT_SPELLCAST_EMPOWER_START")
-					spellEventFrame:RegisterEvent("UNIT_SPELLCAST_EMPOWER_STOP")
-				end
-			end
+        if IS_RETAIL then
+            if ns.constants.IsMidnight then
+                spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_EMPOWER_START", "player")
+                spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_EMPOWER_STOP", "player")
+            else
+                spellEventFrame:RegisterEvent("UNIT_SPELLCAST_EMPOWER_START")
+                spellEventFrame:RegisterEvent("UNIT_SPELLCAST_EMPOWER_STOP")
+            end
+        end
 
-			spellEventFrame:SetScript("OnEvent", function(_, unitEvent, unitType, castId, spellId)
-				if ns.units[unitType] and ns.locationCheck.isAddonEnabled() then
-					ns.units[unitType]:OnSpellEvent(unitEvent, spellId, unitType, castId)
-				end
-			end)
-		end)
+        spellEventFrame:SetScript("OnEvent", function(_, unitEvent, unitType, castId, spellId)
+            if ns.units[unitType] and ns.locationCheck.isAddonEnabled() then
+                ns.units[unitType]:OnSpellEvent(unitEvent, spellId, unitType, castId)
+            end
+        end)
+    end)
 
-		local minUpdateInterval = 0.03
-		local lastUpdateTime = GetTime()
+    local minUpdateInterval = 0.03
+    local lastUpdateTime = GetTime()
 
-		local updateFrame = CreateFrame("Frame", nil, UIParent)
-		updateFrame:SetScript("OnUpdate", function()
-			local time = GetTime()
-			local interval = time - lastUpdateTime
-			if interval > minUpdateInterval then
-				for _, unit in pairs(ns.units) do
-					unit:Update(time, interval)
-				end
-				lastUpdateTime = time
-			end
-		end)
+    local updateFrame = CreateFrame("Frame", nil, UIParent)
+    updateFrame:SetScript("OnUpdate", function()
+        local time = GetTime()
+        local interval = time - lastUpdateTime
+        if interval > minUpdateInterval then
+            for _, unit in pairs(ns.units) do
+                unit:Update(time, interval)
+            end
+            lastUpdateTime = time
+        end
+    end)
 
-		if AddonCompartmentFrame then
-			AddonCompartmentFrame:RegisterAddon({
-				text = "TrufiGCD",
-				icon = 4622474,
-				notCheckable = true,
-				registerForAnyClick = true,
-				func = function(_, btn)
-					if btn.buttonName == "LeftButton" then
-						Settings.OpenToCategory(ns.settingsFrame.frame.name)
-					else
-						ns.settingsFrame.toggleAnchors()
-					end
-				end,
-				funcOnEnter = function(button)
-					MenuUtil.ShowTooltip(button, function(tooltip)
-						tooltip:ClearLines()
-						tooltip:SetText("TrufiGCD")
-						tooltip:AddLine("|cffeda55fLeft-Click|r to open the settings.", 1, 1, 1, true)
-						tooltip:AddLine("|cffeda55fRight-Click|r to show frame anchors.", 1, 1, 1, true)
-						tooltip:Show()
-					end)
-				end,
-				funcOnLeave = function(button)
-					MenuUtil.HideTooltip(button)
-				end,
-			})
-		end
-	end
+    if AddonCompartmentFrame then
+        AddonCompartmentFrame:RegisterAddon({
+            text = "TrufiGCD",
+            icon = 4622474,
+            notCheckable = true,
+            registerForAnyClick = true,
+            func = function(_, btn)
+                if btn.buttonName == "LeftButton" then
+                    Settings.OpenToCategory(ns.settingsFrame.frame.name)
+                else
+                    ns.settingsFrame.toggleAnchors()
+                end
+            end,
+            funcOnEnter = function(button)
+                MenuUtil.ShowTooltip(button, function(tooltip)
+                    tooltip:ClearLines()
+                    tooltip:SetText("TrufiGCD")
+                    tooltip:AddLine("|cffeda55fLeft-Click|r to open the settings.", 1, 1, 1, true)
+                    tooltip:AddLine("|cffeda55fRight-Click|r to show frame anchors.", 1, 1, 1, true)
+                    tooltip:Show()
+                end)
+            end,
+            funcOnLeave = function(button)
+                MenuUtil.HideTooltip(button)
+            end,
+        })
+    end
+end
 
-	if EventUtil and EventUtil.ContinueOnAddOnLoaded then
-		EventUtil.ContinueOnAddOnLoaded(addonName, OnLoad)
-	else
-		local loadFrame = CreateFrame("Frame", nil, UIParent)
-		loadFrame:RegisterEvent("ADDON_LOADED")
-		loadFrame:SetScript("OnEvent", function(self, event, name)
-			if name ~= "TrufiGCD" or event ~= "ADDON_LOADED" then
-				return
-			end
+if EventUtil and EventUtil.ContinueOnAddOnLoaded then
+    EventUtil.ContinueOnAddOnLoaded(addonName, OnLoad)
+else
+    local loadFrame = CreateFrame("Frame", nil, UIParent)
+    loadFrame:RegisterEvent("ADDON_LOADED")
+    loadFrame:SetScript("OnEvent", function(self, event, name)
+        if name ~= "TrufiGCD" or event ~= "ADDON_LOADED" then
+            return
+        end
 
-			OnLoad()
+        OnLoad()
 
-			self:UnregisterEvent("ADDON_LOADED")
-		end)
-	end
+        self:UnregisterEvent("ADDON_LOADED")
+    end)
 end

--- a/TrufiGCD.lua
+++ b/TrufiGCD.lua
@@ -5,118 +5,145 @@
 local IS_RETAIL = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
 
 ---@type string, Namespace
-local _, ns = ...
+local addonName, ns = ...
 
 ---@param unitA UnitType
 ---@param unitB UnitType
 ---@return boolean
 local function areUnitsEqual(unitA, unitB)
-    local nameA = UnitName(unitA)
-    return nameA and nameA == UnitName(unitB) and UnitHealth(unitA) == UnitHealth(unitB)
+	local nameA = UnitName(unitA)
+	return nameA and nameA == UnitName(unitB) and UnitHealth(unitA) == UnitHealth(unitB)
 end
 
 ---@param unitType UnitType
 local function checkIfUnitAlreadyInUse(unitType)
-    for _, existedUnitType in ipairs(ns.constants.unitTypes) do
-        if areUnitsEqual(unitType, existedUnitType) then
-            ns.units[unitType]:Copy(ns.units[existedUnitType])
-            return
-        end
-    end
+	for _, existedUnitType in ipairs(ns.constants.unitTypes) do
+		if areUnitsEqual(unitType, existedUnitType) then
+			ns.units[unitType]:Copy(ns.units[existedUnitType])
+			return
+		end
+	end
 end
 
-local loadFrame = CreateFrame("Frame", nil, UIParent)
-loadFrame:RegisterEvent("ADDON_LOADED")
-loadFrame:SetScript("OnEvent", function(_, event, name)
-    if name ~= "TrufiGCD" or event ~= "ADDON_LOADED" then
-        return
-    end
+do
+	local function OnLoad()
+		ns.settings:Load()
+		ns.settingsFrame.syncWithSettings()
+		ns.blocklistFrame.syncWithSettings()
+		ns.profileFrame.syncWithSettings()
 
-    ns.settings:Load()
-    ns.settingsFrame.syncWithSettings()
-    ns.blocklistFrame.syncWithSettings()
-    ns.profileFrame.syncWithSettings()
+		ns.locationCheck.settingsChanged()
 
-    ns.locationCheck.settingsChanged()
+		if not ns.constants.IsMidnight then
+			local targetFocusChangeFrame = CreateFrame("Frame", nil, UIParent)
+			targetFocusChangeFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
+			targetFocusChangeFrame:RegisterEvent("PLAYER_FOCUS_CHANGED")
+			targetFocusChangeFrame:SetScript("OnEvent", function(_, changeEvent)
+				if changeEvent == "PLAYER_TARGET_CHANGED" then
+					ns.units.target:Clear()
+					if ns.settings.activeProfile.layoutSettings.target.enable then
+						checkIfUnitAlreadyInUse("target")
+					end
+				elseif changeEvent == "PLAYER_FOCUS_CHANGED" then
+					ns.units.focus:Clear()
+					if ns.settings.activeProfile.layoutSettings.focus.enable then
+						checkIfUnitAlreadyInUse("focus")
+					end
+				end
+			end)
+		end
 
-    local targetFocusChangeFrame = CreateFrame("Frame", nil, UIParent)
-    targetFocusChangeFrame:RegisterEvent('PLAYER_TARGET_CHANGED')
-    targetFocusChangeFrame:RegisterEvent('PLAYER_FOCUS_CHANGED')
-    targetFocusChangeFrame:SetScript("OnEvent", function(_, changeEvent)
-        if changeEvent == "PLAYER_TARGET_CHANGED" then
-            ns.units.target:Clear()
-            if ns.settings.activeProfile.layoutSettings.target.enable then
-                checkIfUnitAlreadyInUse("target")
-            end
-        elseif changeEvent == "PLAYER_FOCUS_CHANGED" then
-            ns.units.focus:Clear()
-            if ns.settings.activeProfile.layoutSettings.focus.enable then
-                checkIfUnitAlreadyInUse("focus")
-            end
-        end
-    end)
+		--Delay the initialisation to prevent odd abilities spam at the first world enter
+		C_Timer.After(0.5, function()
+			local spellEventFrame = CreateFrame("Frame", nil, UIParent)
+			if ns.constants.IsMidnight then
+				spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_START", "player")
+				spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_START", "player")
+				spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", "player")
+				spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_STOP", "player")
+				spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_CHANNEL_STOP", "player")
+			else
+				spellEventFrame:RegisterEvent("UNIT_SPELLCAST_START")
+				spellEventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
+				spellEventFrame:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
+				spellEventFrame:RegisterEvent("UNIT_SPELLCAST_STOP")
+				spellEventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP")
+			end
 
-    --Delay the initialisation to prevent odd abilities spam at the first world enter
-    C_Timer.After(0.5, function()
-        local spellEventFrame = CreateFrame("Frame", nil, UIParent)
-        spellEventFrame:RegisterEvent("UNIT_SPELLCAST_START")
-        spellEventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START")
-        spellEventFrame:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
-        spellEventFrame:RegisterEvent("UNIT_SPELLCAST_STOP")
-        spellEventFrame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP")
+			if IS_RETAIL then
+				if ns.constants.IsMidnight then
+					spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_EMPOWER_START", "player")
+					spellEventFrame:RegisterUnitEvent("UNIT_SPELLCAST_EMPOWER_STOP", "player")
+				else
+					spellEventFrame:RegisterEvent("UNIT_SPELLCAST_EMPOWER_START")
+					spellEventFrame:RegisterEvent("UNIT_SPELLCAST_EMPOWER_STOP")
+				end
+			end
 
-        if IS_RETAIL then
-            spellEventFrame:RegisterEvent("UNIT_SPELLCAST_EMPOWER_START")
-            spellEventFrame:RegisterEvent("UNIT_SPELLCAST_EMPOWER_STOP")
-        end
+			spellEventFrame:SetScript("OnEvent", function(_, unitEvent, unitType, castId, spellId)
+				if ns.units[unitType] and ns.locationCheck.isAddonEnabled() then
+					ns.units[unitType]:OnSpellEvent(unitEvent, spellId, unitType, castId)
+				end
+			end)
+		end)
 
-        spellEventFrame:SetScript("OnEvent", function(_, unitEvent, unitType, castId, spellId)
-            if ns.units[unitType] and ns.locationCheck.isAddonEnabled() then
-                ns.units[unitType]:OnSpellEvent(unitEvent, spellId, unitType, castId)
-            end
-        end)
-    end)
+		local minUpdateInterval = 0.03
+		local lastUpdateTime = GetTime()
 
-    local minUpdateInterval = 0.03
-    local lastUpdateTime = GetTime()
+		local updateFrame = CreateFrame("Frame", nil, UIParent)
+		updateFrame:SetScript("OnUpdate", function()
+			local time = GetTime()
+			local interval = time - lastUpdateTime
+			if interval > minUpdateInterval then
+				for _, unit in pairs(ns.units) do
+					unit:Update(time, interval)
+				end
+				lastUpdateTime = time
+			end
+		end)
 
-    local updateFrame = CreateFrame("Frame", nil, UIParent)
-    updateFrame:SetScript("OnUpdate", function()
-        local time = GetTime()
-        local interval = time - lastUpdateTime
-        if interval > minUpdateInterval then
-            for _, unit in pairs(ns.units) do
-                unit:Update(time, interval)
-            end
-            lastUpdateTime = time
-        end
-    end)
-end)
+		if AddonCompartmentFrame then
+			AddonCompartmentFrame:RegisterAddon({
+				text = "TrufiGCD",
+				icon = 4622474,
+				notCheckable = true,
+				registerForAnyClick = true,
+				func = function(_, btn)
+					if btn.buttonName == "LeftButton" then
+						Settings.OpenToCategory(ns.settingsFrame.frame.name)
+					else
+						ns.settingsFrame.toggleAnchors()
+					end
+				end,
+				funcOnEnter = function(button)
+					MenuUtil.ShowTooltip(button, function(tooltip)
+						tooltip:ClearLines()
+						tooltip:SetText("TrufiGCD")
+						tooltip:AddLine("|cffeda55fLeft-Click|r to open the settings.", 1, 1, 1, true)
+						tooltip:AddLine("|cffeda55fRight-Click|r to show frame anchors.", 1, 1, 1, true)
+						tooltip:Show()
+					end)
+				end,
+				funcOnLeave = function(button)
+					MenuUtil.HideTooltip(button)
+				end,
+			})
+		end
+	end
 
-if IS_RETAIL then
-    AddonCompartmentFrame:RegisterAddon({
-        text = "TrufiGCD",
-        icon = 4622474,
-        notCheckable = true,
-        registerForAnyClick = true,
-        func = function(_, btn)
-            if btn.buttonName == "LeftButton" then
-                Settings.OpenToCategory(ns.settingsFrame.frame.name)
-            else
-                ns.settingsFrame.toggleAnchors()
-            end
-        end,
-        funcOnEnter = function(button)
-            MenuUtil.ShowTooltip(button, function(tooltip)
-                tooltip:ClearLines()
-                tooltip:SetText("TrufiGCD")
-                tooltip:AddLine("|cffeda55fLeft-Click|r to open the settings.", 1, 1, 1, true)
-                tooltip:AddLine("|cffeda55fRight-Click|r to show frame anchors.", 1, 1, 1, true)
-                tooltip:Show()
-            end)
-        end,
-        funcOnLeave = function(button)
-            MenuUtil.HideTooltip(button)
-        end,
-    })
+	if EventUtil and EventUtil.ContinueOnAddOnLoaded then
+		EventUtil.ContinueOnAddOnLoaded(addonName, OnLoad)
+	else
+		local loadFrame = CreateFrame("Frame", nil, UIParent)
+		loadFrame:RegisterEvent("ADDON_LOADED")
+		loadFrame:SetScript("OnEvent", function(self, event, name)
+			if name ~= "TrufiGCD" or event ~= "ADDON_LOADED" then
+				return
+			end
+
+			OnLoad()
+
+			self:UnregisterEvent("ADDON_LOADED")
+		end)
+	end
 end

--- a/TrufiGCD.toc
+++ b/TrufiGCD.toc
@@ -1,4 +1,4 @@
-## Interface: 110207, 120000, 120001
+## Interface: 120000, 120001
 ## Interface-Classic: 11507
 ## Interface-Cata: 40402
 ## Interface-Mists: 50500

--- a/TrufiGCD.toc
+++ b/TrufiGCD.toc
@@ -1,4 +1,4 @@
-## Interface: 110207
+## Interface: 110207, 120000, 120001
 ## Interface-Classic: 11507
 ## Interface-Cata: 40402
 ## Interface-Mists: 50500


### PR DESCRIPTION
- closes https://github.com/Trufi/TrufiGCD/issues/27
- only conditionally registers non-player events
- adjusted Settings.OpenToCategory to use the native `:GetID()` as - while you still can override `frame.ID`, it will no longer accept that override value and throw an error/expect an int
- slightly modernized addon load option as it's no longer needed to create a frame ourselves


proof it works:
<img width="1476" height="1122" alt="image" src="https://github.com/user-attachments/assets/4e884d12-7309-45ae-a15c-f817663f1296" />

settings are slimmed down to player-only:
<img width="1157" height="699" alt="image" src="https://github.com/user-attachments/assets/3ea8db94-4d69-4242-863d-a276f39ccad1" />
